### PR TITLE
Java 7, 6 and 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A Markov Chain library for Java. Supports extensible tokenization and an arbitra
 
 **Build:**
  - Maven 3
- - JDK 8
+ - JDK 5 or newer
  
 **Run:**
- - JRE 8
+ - JRE 5 or newer
 
 ## Building
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	</dependencies>
 
 	<properties>
-		<jdk.version>1.8</jdk.version>
+		<jdk.version>1.5</jdk.version>
 	</properties>
 
 	<build>

--- a/src/main/java/io/vedder/ml/markov/ExampleMain.java
+++ b/src/main/java/io/vedder/ml/markov/ExampleMain.java
@@ -20,7 +20,7 @@ import io.vedder.ml.markov.tokens.Token;
 
 public class ExampleMain {
 
-	static Logger log = Logger.getLogger(ExampleMain.class.getName());
+	static Logger log = Logger.getLogger(ExampleMain.class);
 	public static boolean verbose = false;
 
 	private static int lookback = 1;

--- a/src/main/java/io/vedder/ml/markov/ExampleMain.java
+++ b/src/main/java/io/vedder/ml/markov/ExampleMain.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -64,7 +63,7 @@ public class ExampleMain {
 
 		// Kicks off the tokenization process
 
-		List<Collection<Token>> tokensCollections = new LinkedList<>();
+		List<Collection<Token>> tokensCollections = new LinkedList<Collection<Token>>();
 
 		// Creates Lists of tokens
 		for (int i = 0; i < numSent / 2; i++) {
@@ -78,7 +77,10 @@ public class ExampleMain {
 
 		// Consumer consumes both types of collections
 		log.info("Printing Tokens...\n" + "===============\n");
-		tokensCollections.forEach(l -> tc.consume(l));
+		
+		for(Collection<Token> l: tokensCollections) {
+			tc.consume(l);
+		}
 
 	}
 
@@ -91,8 +93,10 @@ public class ExampleMain {
 		if (args.size() < 3 || !args.contains("-f")) {
 			printUsageAndExit();
 		}
-
-		args = args.stream().map(a -> a.trim()).collect(Collectors.toList());
+		
+		for(String a : args) {
+			a = a.trim();
+		}
 
 		if (args.contains("-v")) {
 			verbose = true;

--- a/src/main/java/io/vedder/ml/markov/LookbackContainer.java
+++ b/src/main/java/io/vedder/ml/markov/LookbackContainer.java
@@ -18,7 +18,7 @@ public class LookbackContainer {
 
 	public LookbackContainer(int maxSize, List<Token> ts) {
 		MAX_SIZE = maxSize;
-		tokenList = new ArrayList<>(ts);
+		tokenList = new ArrayList<Token>(ts);
 	}
 
 	/**
@@ -29,7 +29,7 @@ public class LookbackContainer {
 	 */
 	public void addToken(Token token) {
 		if (tokenList == null) {
-			tokenList = new LinkedList<>();
+			tokenList = new LinkedList<Token>();
 		}
 
 		if (tokenList.size() >= MAX_SIZE) {
@@ -48,7 +48,7 @@ public class LookbackContainer {
 	}
 
 	public LookbackContainer shrinkContainer() {
-		List<Token> lst = new LinkedList<>(tokenList);
+		List<Token> lst = new LinkedList<Token>(tokenList);
 		if (!lst.isEmpty()) {
 			lst.remove(0);
 		}

--- a/src/main/java/io/vedder/ml/markov/collection/TokenCollection.java
+++ b/src/main/java/io/vedder/ml/markov/collection/TokenCollection.java
@@ -13,62 +13,50 @@ public abstract class TokenCollection implements Collection<Token> {
 		this.th = th;
 	}
 
-	@Override
 	public boolean isEmpty() {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public int size() {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public boolean contains(Object o) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public Object[] toArray() {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public <T> T[] toArray(T[] a) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public boolean add(Token e) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public boolean remove(Object o) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public boolean containsAll(Collection<?> c) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public boolean addAll(Collection<? extends Token> c) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public boolean removeAll(Collection<?> c) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public boolean retainAll(Collection<?> c) {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}
 
-	@Override
 	public void clear() {
 		throw new RuntimeException("Cannot call this method on a lazy TokenCollection");
 	}

--- a/src/main/java/io/vedder/ml/markov/collection/file/FileTokenCollection.java
+++ b/src/main/java/io/vedder/ml/markov/collection/file/FileTokenCollection.java
@@ -15,7 +15,6 @@ public class FileTokenCollection extends TokenCollection {
 		this.LOOKBACK = lookBack;
 	}
 
-	@Override
 	public Iterator<Token> iterator() {
 		return new FileTokenCollectionIterator(th, LOOKBACK);
 	}

--- a/src/main/java/io/vedder/ml/markov/collection/file/FileTokenCollectionIterator.java
+++ b/src/main/java/io/vedder/ml/markov/collection/file/FileTokenCollectionIterator.java
@@ -29,12 +29,10 @@ public class FileTokenCollectionIterator implements Iterator<Token> {
 		return t;
 	}
 
-	@Override
 	public boolean hasNext() {
 		return (currentToken != null && currentToken != DELIMIT_TOKEN);
 	}
 
-	@Override
 	public Token next() {
 		Token t = currentToken;
 		currentToken = nextToken();

--- a/src/main/java/io/vedder/ml/markov/consumer/file/FileTokenConsumer.java
+++ b/src/main/java/io/vedder/ml/markov/consumer/file/FileTokenConsumer.java
@@ -12,12 +12,12 @@ public class FileTokenConsumer extends TokenConsumer {
 	@Override
 	public void consume(Collection<Token> collection) {
 		List<String> punctuation = Arrays.asList(",", ";", ":", ".", "?", "!", "-");
-		collection.forEach(w -> {
+		for(Token w : collection) {
 			if (!punctuation.contains(w.toString())) {
 				System.out.print(" ");
 			}
 			System.out.print(w.toString());
-		});
+		}
 		System.out.print("\n");
 	}
 

--- a/src/main/java/io/vedder/ml/markov/generator/file/FileGenerator.java
+++ b/src/main/java/io/vedder/ml/markov/generator/file/FileGenerator.java
@@ -23,7 +23,7 @@ public class FileGenerator extends Generator {
 
 	@Override
 	public List<Token> generateTokenList() {
-		List<Token> line = new LinkedList<>();
+		List<Token> line = new LinkedList<Token>();
 
 		LookbackContainer c = new LookbackContainer(LOOKBACK, DELIMIT_TOKEN);
 		Token t = null;

--- a/src/main/java/io/vedder/ml/markov/holder/MapTokenHolder.java
+++ b/src/main/java/io/vedder/ml/markov/holder/MapTokenHolder.java
@@ -26,7 +26,7 @@ public class MapTokenHolder implements TokenHolder {
 
 	public MapTokenHolder(int mapInitialSize) {
 		r = new Random();
-		tokenMap = new ConcurrentHashMap<>(mapInitialSize);
+		tokenMap = new ConcurrentHashMap<LookbackContainer, Map<Token, Integer>>(mapInitialSize);
 	}
 
 	public void addToken(LookbackContainer lbc, Token next) {
@@ -34,7 +34,7 @@ public class MapTokenHolder implements TokenHolder {
 		if (tokenMap.containsKey(lbc)) {
 			nextElementMap = tokenMap.get(lbc);
 		} else {
-			nextElementMap = new HashMap<>();
+			nextElementMap = new HashMap<Token, Integer>();
 		}
 
 		if (!nextElementMap.isEmpty() && nextElementMap.containsKey(next)) {
@@ -79,15 +79,17 @@ public class MapTokenHolder implements TokenHolder {
 	@Override
 	public String toString() {
 		StringBuffer sb = new StringBuffer();
-		List<String> lst = new LinkedList<>();
+		List<String> lst = new LinkedList<String>();
 		for (Entry<LookbackContainer, Map<Token, Integer>> e : tokenMap.entrySet()) {
 			lst.add(e.toString() + "\n");
 
 		}
 		Collections.sort(lst);
 
-		lst.forEach(l -> sb.append(l));
-
+		for(String l : lst) {
+			sb.append(l);
+		}
+		
 		return sb.toString();
 	}
 

--- a/src/main/java/io/vedder/ml/markov/threading/JobManager.java
+++ b/src/main/java/io/vedder/ml/markov/threading/JobManager.java
@@ -5,12 +5,11 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
-import io.vedder.ml.markov.ExampleMain;
 import io.vedder.ml.markov.tokenizer.Tokenizer;
 
 public class JobManager {
 
-	static Logger log = Logger.getLogger(ExampleMain.class.getName());
+	static Logger log = Logger.getLogger(JobManager.class);
 
 	private List<Runnable> jobs = null;
 

--- a/src/main/java/io/vedder/ml/markov/threading/JobManager.java
+++ b/src/main/java/io/vedder/ml/markov/threading/JobManager.java
@@ -15,7 +15,7 @@ public class JobManager {
 	private List<Runnable> jobs = null;
 
 	public JobManager() {
-		jobs = new LinkedList<>();
+		jobs = new LinkedList<Runnable>();
 	}
 
 	public void addTokenizer(Tokenizer t) {
@@ -27,7 +27,7 @@ public class JobManager {
 	}
 
 	public void runAll() {
-		List<Thread> threads = new LinkedList<>();
+		List<Thread> threads = new LinkedList<Thread>();
 		for (Runnable r : jobs) {
 			Thread th = new Thread(r);
 			threads.add(th);

--- a/src/main/java/io/vedder/ml/markov/threading/TokenizerJob.java
+++ b/src/main/java/io/vedder/ml/markov/threading/TokenizerJob.java
@@ -2,12 +2,11 @@ package io.vedder.ml.markov.threading;
 
 import org.apache.log4j.Logger;
 
-import io.vedder.ml.markov.ExampleMain;
 import io.vedder.ml.markov.tokenizer.Tokenizer;
 
 public class TokenizerJob implements Runnable {
 
-	static Logger log = Logger.getLogger(ExampleMain.class.getName());
+	static Logger log = Logger.getLogger(TokenizerJob.class);
 	
 	private Tokenizer tokenizer;
 

--- a/src/main/java/io/vedder/ml/markov/threading/TokenizerJob.java
+++ b/src/main/java/io/vedder/ml/markov/threading/TokenizerJob.java
@@ -15,7 +15,6 @@ public class TokenizerJob implements Runnable {
 		this.tokenizer = tokenizer;
 	}
 
-	@Override
 	public void run() {
 		tokenizer.tokenize();
 		log.info("Tokenizer job complete!\n");

--- a/src/main/java/io/vedder/ml/markov/tokenizer/file/FileTokenizer.java
+++ b/src/main/java/io/vedder/ml/markov/tokenizer/file/FileTokenizer.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import org.apache.log4j.Logger;
 
-import io.vedder.ml.markov.ExampleMain;
 import io.vedder.ml.markov.LookbackContainer;
 import io.vedder.ml.markov.holder.TokenHolder;
 import io.vedder.ml.markov.tokenizer.Tokenizer;
@@ -26,7 +25,7 @@ import io.vedder.ml.markov.utils.Utils;
  */
 public class FileTokenizer extends Tokenizer {
 
-	static Logger log = Logger.getLogger(ExampleMain.class.getName());
+	static Logger log = Logger.getLogger(FileTokenizer.class);
 
 	private final int LOOKBACK;
 	private final Set<String> END_MARKS;

--- a/src/main/java/io/vedder/ml/markov/tokenizer/file/FileTokenizer.java
+++ b/src/main/java/io/vedder/ml/markov/tokenizer/file/FileTokenizer.java
@@ -6,12 +6,11 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 
-import io.vedder.ml.markov.LookbackContainer;
 import io.vedder.ml.markov.ExampleMain;
+import io.vedder.ml.markov.LookbackContainer;
 import io.vedder.ml.markov.holder.TokenHolder;
 import io.vedder.ml.markov.tokenizer.Tokenizer;
 import io.vedder.ml.markov.tokens.Token;
@@ -38,7 +37,7 @@ public class FileTokenizer extends Tokenizer {
 
 	public FileTokenizer(TokenHolder th, int lookback, String filePath) {
 		super(th);
-		END_MARKS = new HashSet<>(Arrays.asList(".", "?", "!"));
+		END_MARKS = new HashSet<String>(Arrays.asList(".", "?", "!"));
 		LOOKBACK = lookback;
 		this.filePath = filePath;
 	}
@@ -59,7 +58,7 @@ public class FileTokenizer extends Tokenizer {
 		for (int wordIndex = LOOKBACK; wordIndex < tokens.size() - 1; wordIndex++) {
 
 			// List for the lookback
-			List<Token> lookBackList = new ArrayList<>(this.LOOKBACK);
+			List<Token> lookBackList = new ArrayList<Token>(this.LOOKBACK);
 
 			Token t = null;
 
@@ -81,14 +80,15 @@ public class FileTokenizer extends Tokenizer {
 	}
 
 	private List<Token> getTokens(List<String> listStrings) {
-		List<Token> tokenList = new LinkedList<>();
+		List<Token> tokenList = new LinkedList<Token>();
 		tokenList.add(DELIMIT_TOKEN);
-		listStrings.forEach(s -> {
+		
+		for(String s : listStrings) {
 			tokenList.add(new StringToken(s));
 			if (END_MARKS.contains(s)) {
 				tokenList.add(DELIMIT_TOKEN);
 			}
-		});
+		}
 
 		// check to see if ends with delimiter token
 		if (tokenList.get(tokenList.size() - 1) != DELIMIT_TOKEN) {
@@ -100,11 +100,17 @@ public class FileTokenizer extends Tokenizer {
 	private List<String> splitStrings(List<String> lines) {
 		// Regex from:
 		// http://stackoverflow.com/questions/24222730/split-a-string-and-separate-by-punctuation-and-whitespace
-		// Sorry about the functional mess...
-		List<String> splits = lines.parallelStream()
-				.map(l -> Arrays.asList(l.replaceAll("  ", " ")
-						.split("\\s+|(?=\\W\\p{Punct}|\\p{Punct}\\W)|(?<=\\W\\p{Punct}|\\p{Punct}\\W})")))
-				.flatMap(l -> l.stream()).filter(w -> !w.isEmpty() && !w.equals("")).collect(Collectors.toList());
+		List<String> splits = new ArrayList<String>();
+		List<String> temp;
+		for (String s : lines) {
+			temp = Arrays.asList(s.replaceAll("  ", " ")
+					.split("\\s+|(?=\\W\\p{Punct}|\\p{Punct}\\W)|(?<=\\W\\p{Punct}|\\p{Punct}\\W})"));
+			for (String t : temp) {
+				if (t != "" && !t.isEmpty()) {
+					splits.add(t);
+				}
+			}
+		}
 		return splits;
 	}
 }

--- a/src/main/java/io/vedder/ml/markov/utils/Utils.java
+++ b/src/main/java/io/vedder/ml/markov/utils/Utils.java
@@ -1,10 +1,11 @@
 package io.vedder.ml.markov.utils;
 
+import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -25,14 +26,28 @@ public class Utils {
 			e.printStackTrace();
 		}
 	}
-	
+
 	public static List<String> readFile(String filePath) {
-		List<String> lines = new LinkedList<>();
+		List<String> lines = new LinkedList<String>();
+		BufferedReader br = null;
 		try {
-			Files.lines(new File(filePath).toPath()).forEach(l -> lines.add(l + "\n"));
+			br = new BufferedReader(new FileReader(new File(filePath)));
+			String line;
+			while ((line = br.readLine()) != null) {
+				lines.add(line + "\n");
+			}
 		} catch (IOException e) {
 			e.printStackTrace();
+		} finally {
+			if (br != null) {
+				try {
+					br.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
 		}
+
 		return lines;
 	}
 }


### PR DESCRIPTION
Hi Kyle,

as we agreed, I've started reviewing your code. In this first pull request I've added support to Java 7, 6 and 5. To do that, I've removed lambdas and Java FP, converting them into their respective OOP equivalent (mostly for loops), I've removed the diamond operator to all the collection (type inference has been removed and hard-coded) and the Override annotation from interface overriding (Java 5 allows overriding only class methods).

Also, while I was at it, I've noticed that some classes used to log with a reference to the ExampleMain.class. Since that's only an example, I've removed that reference and gave each class its own logger.

Please review the changes when you have time and pull them to your repository if you feel like. 

Thank you for this awesome library and have a nice day!